### PR TITLE
Switch all projects to .NET 7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
-.git
-.github
+**/.*
 **/bin
 **/obj
 **/Dockerfile

--- a/Greeter.Client/Greeter.Client.csproj
+++ b/Greeter.Client/Greeter.Client.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>Greater.Client</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Greeter.Common/Greeter.Common.csproj
+++ b/Greeter.Common/Greeter.Common.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>Greater.Common</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Greeter.Grpc/Greeter.Grpc.csproj
+++ b/Greeter.Grpc/Greeter.Grpc.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Greater.Grpc</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="1.9.106" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.1.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Greeter.Common\Greeter.Common.csproj" GenerateGrpc="true"/>

--- a/Greeter.Service/Dockerfile
+++ b/Greeter.Service/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 WORKDIR /work
 
@@ -17,8 +17,8 @@ RUN dotnet publish -c Release -r linux-musl-x64 --no-restore --self-contained -p
 
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine
-ENV ASPNETCORE_URLS "http://*:80;https://*:443"
+FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine
+ENV URLS "http://*:80;https://*:443"
 ENV Logging__Console__FormatterName ""
 WORKDIR /app
 

--- a/Greeter.Service/Greeter.Service.csproj
+++ b/Greeter.Service/Greeter.Service.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Greeter.Service</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Greeter.Service/appsettings.json
+++ b/Greeter.Service/appsettings.json
@@ -2,10 +2,11 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Information"
     }
   },
   "AllowedHosts": "*",
+  "Urls": "http://*:5000;https://*:5001",
   "Kestrel": {
     "EndpointDefaults": {
       "Protocols": "Http2"

--- a/Greeter.Test/Greeter.Test.csproj
+++ b/Greeter.Test/Greeter.Test.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Greater.Grpc.Test</RootNamespace>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>Greater.Test</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="1.9.106" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.1.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
Also switch to `IndependentReserve.Grpc.Tools` version `2.*.*` which works on .NET 7
`IndependentReserve.Grpc.Tools` version `1.*.*` supports .NET Framework projects but works only up to .NET 6