### PR TITLE
Switch to `IndependentReserve.Grpc.Tools` version `2.2.*`

### DIFF
--- a/Greeter.Client/Program.cs
+++ b/Greeter.Client/Program.cs
@@ -2,7 +2,10 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
+using static Greeter.Common.Title;
 using static System.Console;
+
 
 using var host = Host.CreateDefaultBuilder(args).Build();
 var config = host.Services
@@ -24,20 +27,36 @@ var clientEx = new Greeter.Common.Grpc.GreeterExtendedServiceGrpcClient(config, 
 
 var person = new Person
 {
-    Title = Greeter.Common.Title.Mr,
-    FirstName = "Agent",
-    LastName = "Smith",
-    Addresses = new[]
+    Name = new()
     {
-        new Address
+        Title = Mr,
+        FirstName = "Eric",
+        LastName = "Cartman",
+    },
+    OtherNames = new()
+    {
+        new(Miss, "Erica", "Cartman"),
+        new(Miss, "Mitch", "Conner"),
+    },
+    Aliases = new[]
+    {
+        "The Coon",
+        "A.W.E.S.O.M.-O 4000",
+    },
+    Details = new()
+    {
+        DateOfBirth = new(DateTime.Now.Year - 10, 7, 1),
+        Height = 5.5,
+        Length = 1.2M,
+        Addresses = new Address[]
         {
-            Street = new[]
+            new()
             {
-                "221B Baker Street"
-            },
-            City = "London",
-            Postcode = 90210
-        }
+                Street = new[] { "28201 E. Bonanza St." },
+                City = "South Park",
+                State = "Colorado",
+            }
+        },
     }
 };
 

--- a/Greeter.Client/Program.cs
+++ b/Greeter.Client/Program.cs
@@ -31,7 +31,10 @@ var person = new Person
     {
         new Address
         {
-            Street = "221B Baker Street",
+            Street = new[]
+            {
+                "221B Baker Street"
+            },
             City = "London",
             Postcode = 90210
         }

--- a/Greeter.Common/Dto/Address.cs
+++ b/Greeter.Common/Dto/Address.cs
@@ -3,6 +3,6 @@ namespace Greeter.Common;
 public readonly record struct Address(
     string[] Street,
     string City,
-    string State,
-    int Postcode
+    string? State,
+    int? Postcode
 );

--- a/Greeter.Common/Dto/Address.cs
+++ b/Greeter.Common/Dto/Address.cs
@@ -1,7 +1,7 @@
 namespace Greeter.Common;
 
 public readonly record struct Address(
-    string Street,
+    string[] Street,
     string City,
     string State,
     int Postcode

--- a/Greeter.Common/Dto/Name.cs
+++ b/Greeter.Common/Dto/Name.cs
@@ -1,0 +1,8 @@
+namespace Greeter.Common;
+
+public readonly record struct Name(
+    Title Title,
+    string FirstName,
+    string LastName,
+    string? MiddleName = null
+);

--- a/Greeter.Common/Dto/Person.cs
+++ b/Greeter.Common/Dto/Person.cs
@@ -1,8 +1,8 @@
 namespace Greeter.Common;
 
 public readonly record struct Person(
-    Title Title,
-    string FirstName,
-    string LastName,
-    Address[] Addresses
+    Name Name,
+    List<Name> OtherNames,
+    string[] Aliases,
+    PersonDetails Details
 );

--- a/Greeter.Common/Dto/PersonDetails.cs
+++ b/Greeter.Common/Dto/PersonDetails.cs
@@ -1,0 +1,8 @@
+namespace Greeter.Common;
+
+public readonly record struct PersonDetails(
+    DateTime DateOfBirth,
+    double Height,
+    decimal Length,
+    Address[] Addresses
+);

--- a/Greeter.Grpc/Greeter.Grpc.csproj
+++ b/Greeter.Grpc/Greeter.Grpc.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.1.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.2.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Greeter.Common\Greeter.Common.csproj" GenerateGrpc="true"/>

--- a/Greeter.Service/Dockerfile
+++ b/Greeter.Service/Dockerfile
@@ -13,7 +13,7 @@ RUN dotnet restore -r linux-musl-x64 ./Greeter.Service
 
 # Build and publish solution to /publish
 COPY . .
-RUN dotnet publish -c Release -r linux-musl-x64 --no-restore --self-contained -p:PublishTrimmed=True -o /publish Greeter.Service
+RUN dotnet publish -c Release -r linux-musl-x64 --no-restore --self-contained -o /publish Greeter.Service
 
 
 # Build runtime image

--- a/Greeter.Service/GreeterImpl.cs
+++ b/Greeter.Service/GreeterImpl.cs
@@ -12,27 +12,51 @@ public class GreeterImpl : IGreeterService, IGreeterExtendedService
 
     public IEnumerable<Greeting> SayGreetings(Person person)
     {
-        var addressLines = person.Addresses?.FirstOrDefault() switch
+        var name = person.Name;
+
+        var otherNames = person.OtherNames
+            .Select(name => name switch
+            {
+                var (_, first, second, _) =>
+                    $"\"{string.Join(' ', new[] { first, second, })}\""
+            });
+
+        var (dob, height, length, addresses) = person.Details;
+        var detailLines = new[]
+        {
+            "You details are:",
+            $"DOB: {dob:dd MMMM yyyy}",
+            $"Height: {height}",
+            $"Length: {length}",
+            "",
+        };
+
+        var addressLines = addresses?.FirstOrDefault() switch
         {
             null => Enumerable.Empty<string>(),
             Address address => new[]
             {
-                "Living at:",
+                "You live at:",
                 string.Join(NewLine, address.Street),
                 address.City,
                 address.State,
-                $"{address.Postcode}"
+                address.Postcode?.ToString()
             }.OfType<string>()
         };
+
         return new[]
         {
             new Greeting
             {
-                Subject = $"Hello {person.Title} {person.LastName}",
+                Subject = $"Hello {name.Title} {name.LastName}!",
                 Lines = new[]
                 {
-                    $"Wellcome dear {person.FirstName} {person.LastName}!",
+                    "",
+                    $"Dear {name.FirstName} {name.LastName}{(otherNames.Any() ?
+                        $" (aka: {string.Join(" and ", otherNames)})" : "")},",
+                    "",
                 }
+                .Concat(detailLines)
                 .Concat(addressLines)
             }
         };

--- a/Greeter.Service/GreeterImpl.cs
+++ b/Greeter.Service/GreeterImpl.cs
@@ -1,4 +1,5 @@
 using Greeter.Common;
+using static System.Environment;
 
 namespace Greeter.Service;
 
@@ -17,11 +18,11 @@ public class GreeterImpl : IGreeterService, IGreeterExtendedService
             Address address => new[]
             {
                 "Living at:",
-                address.Street,
+                string.Join(NewLine, address.Street),
                 address.City,
                 address.State,
                 $"{address.Postcode}"
-            }.Where(l => l is not null)
+            }.OfType<string>()
         };
         return new[]
         {

--- a/Greeter.Test/Greeter.Test.csproj
+++ b/Greeter.Test/Greeter.Test.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.1.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.2.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />


### PR DESCRIPTION
- Version [2.2.114](https://www.nuget.org/packages/IndependentReserve.Grpc.Tools/2.2.114):
  - Works on any `TargetFramework` from .NET Framework 4.6.1 to .NET 7
  - Contains Fixes and performance improvements in `NullableCollection` area
- More involved example DTO which now uses:  
  `string?`, `string[]`, `double`, `decimal`, `DateTime`, `List<Name>`
- Do not `PublishTrimmed` in `docker build` to speed up CI
