### PR TITLE
More version info in build log

### DIFF
--- a/Greeter.Service/Dockerfile
+++ b/Greeter.Service/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet dev-certs https
 COPY Greeter.Common/*.csproj ./Greeter.Common/
 COPY Greeter.Grpc/*.csproj ./Greeter.Grpc/
 COPY Greeter.Service/*.csproj ./Greeter.Service/
-RUN dotnet restore -r linux-musl-x64 ./Greeter.Service
+RUN dotnet restore -v d -r linux-musl-x64 ./Greeter.Service
 
 # Build and publish solution to /publish
 COPY . .


### PR DESCRIPTION
`RUN dotnet restore` in `docker build` with more details
Which is useful to check the actual `IndependentReserve.Grpc.Tools` [package version](https://github.com/EduardSergeev/GreeterService/actions/runs/4368896423/jobs/7642059353#step:3:2462) was restored