### PR TITLE
`IndependentReserve.Grpc.Tools` version `2.3.*`

### DIFF
--- a/Greeter.Grpc/Greeter.Grpc.csproj
+++ b/Greeter.Grpc/Greeter.Grpc.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.2.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.3.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Greeter.Common\Greeter.Common.csproj" GenerateGrpc="true" />

--- a/Greeter.Test/Greeter.Test.csproj
+++ b/Greeter.Test/Greeter.Test.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.2.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="2.3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
Version `2.3.124` changes:
1. Use collection argument type namespace instead of collection type namespace, e.g.:
   Instead of:

   ```proto
   syntax = "proto3";
   
   package system.collections.generic;
   
   option csharp_namespace = "System.Collections.Generic.Grpc";
   
   import "Protos/Greeter/Common/Address.proto";
   
   message CollectionOfAddress {
     repeated greeter.common.Address items = 1;
   }
   ```

   Latest version generates:

   ```proto
   syntax = "proto3";
   
   package greeter.common;
   
   option csharp_namespace = "Greeter.Common.Grpc";
   
   import "Protos/Greeter/Common/Address.proto";
   
   message CollectionOfAddress {
     repeated greeter.common.Address items = 1;
   }
   ```