### PR TITLE
Execute `Greeter.Client` twice in `docker-test`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,10 @@ jobs:
     - name: dotnet run 
       run: |
         cd Greeter.Client
-        dotnet run -c Release
+        # First call to service is slower due to AutoMapper initialisation
+        dotnet run -c Release > /dev/null
+        # For proper gRPC timing in service logs
+        dotnet run --no-build -c Release
     - name: docker logs
       run: docker logs greeter-service
     - name: docker stop


### PR DESCRIPTION
For more accurate gRPC method call timing info in `Greeter.Service` logs
First call is much slower since `AutoMapper` has to compile its mappings