### PR TITLE
Make `IGreeterExtendedService` more synchronous

### DIFF
--- a/Greeter.Client/Program.cs
+++ b/Greeter.Client/Program.cs
@@ -62,11 +62,13 @@ var person = new Person
     }
 };
 
-#pragma warning disable CS1998
-async IAsyncEnumerable<Person> People()
+IEnumerable<Person> People()
 {
     yield return person;
-    yield return person;
+    yield return person with
+    {
+        Name = person.OtherNames[0]
+    };
 }
 
 
@@ -91,14 +93,15 @@ await foreach(var line in clientEx.StreamGreetingAsync(person))
     WriteLine(line);
 }
 
-foreach(var greeting in clientEx.StreamGreetings(People()))
+foreach(var line in clientEx.StreamGreetings(People()))
 {
-    WriteGreeting(greeting);
+    WriteLine(line);
 }
-await foreach(var greeting in clientEx.StreamGreetingsAsync(People()))
+await foreach(var line in clientEx.StreamGreetingsAsync(People()))
 {
-    WriteGreeting(greeting);
+    WriteLine(line);
 }
+
 
 void WriteGreeting(Greeting greeting)
 {

--- a/Greeter.Common/IGreeterExtendedService.cs
+++ b/Greeter.Common/IGreeterExtendedService.cs
@@ -3,7 +3,7 @@
 public interface IGreeterExtendedService
 {
     Greeting SayGreeting(Person person);
-    IEnumerable<Greeting> SayGreetings(IAsyncEnumerable<Person> people);
-    IAsyncEnumerable<string> StreamGreetingAsync(Person person);
-    IAsyncEnumerable<Greeting> StreamGreetingsAsync(IAsyncEnumerable<Person> people);
+    IEnumerable<Greeting> SayGreetings(IEnumerable<Person> people);
+    IEnumerable<string> StreamGreeting(Person person);
+    IEnumerable<string> StreamGreetings(IEnumerable<Person> people);
 }

--- a/Greeter.Service/Services/GreeterExtended.cs
+++ b/Greeter.Service/Services/GreeterExtended.cs
@@ -21,28 +21,21 @@ public class GreeterExtended : IGreeterExtendedService
         return GenerateGreeting(person);
     }
 
-    public IEnumerable<Greeting> SayGreetings(IAsyncEnumerable<Person> people)
+    public IEnumerable<Greeting> SayGreetings(IEnumerable<Person> people)
     {
-        return people.ToBlockingEnumerable().Select(GenerateGreeting);
+        return people.Select(GenerateGreeting);
     }
 
-    #pragma warning disable CS1998
-    public async IAsyncEnumerable<string> StreamGreetingAsync(Person person)
+    public IEnumerable<string> StreamGreeting(Person person)
     {
         var (subject, lines) = GenerateGreeting(person);
-        yield return subject;
-        foreach(var line in lines)
-        {
-            yield return line;
-        }
+        return lines.Prepend(subject);
     }
 
-    public async IAsyncEnumerable<Greeting> StreamGreetingsAsync(IAsyncEnumerable<Person> people)
+    public IEnumerable<string> StreamGreetings(IEnumerable<Person> people)
     {
-        await foreach(var person in people)
-        {
-            yield return GenerateGreeting(person);
-        }
+        var greetings = people.Select(GenerateGreeting);
+        return greetings.SelectMany(greeting => greeting.Lines.Prepend(greeting.Subject));
     }
 
 


### PR DESCRIPTION
It makes more sense to keep it purely synchronous (from service's point of view)
While clients can still use both synchronous and asynchronous methods just like before
NB: gRPC streaming now handles both `IAsyncEnumerable<>` and `IEnumerable<>`