### PR TITLE
Switch to version `3.2.*`

### DIFF
--- a/Greeter.Client/Program.cs
+++ b/Greeter.Client/Program.cs
@@ -57,6 +57,7 @@ var person = new Person
                 City = "South Park",
                 State = "Colorado",
                 Country = "USA",
+                Postcode = 80440
             },
         },
     }

--- a/Greeter.Common/Dto/Address.cs
+++ b/Greeter.Common/Dto/Address.cs
@@ -5,6 +5,6 @@ public readonly record struct Address
     string[] Street,
     string City,
     string? State,
-    int? Postcode,
+    uint? Postcode,
     string? Country
 );

--- a/Greeter.Grpc/Greeter.Grpc.csproj
+++ b/Greeter.Grpc/Greeter.Grpc.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="3.1.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="3.2.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Greeter.Common\Greeter.Common.csproj" GenerateGrpc="true" />

--- a/Greeter.Test/Greeter.Test.csproj
+++ b/Greeter.Test/Greeter.Test.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="3.1.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="3.2.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
Version `3.2.146` changes:
- Instead of mapping unsigned numeric .NET types to `fixed*` Protobuf type map them to variable-length Protobuf types:
  - `UInt32` -> `uint32`
  - `UInt64` -> `uint64`
  
  This fixes compilation error for .NET properties of nullable unsigned numeric type, e.g. `uint?`
  Variable-length Protobuf types should also be generally more efficient in terms of encoding