### PR TITLE
Add benchmark results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,4 +155,5 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: ad-m/github-push-action@master
       with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ env.DOCS_BRANCH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: build
 
 on:
   push:
+    branches-ignore:
+      - 'docs'
+env:
+  BENCH_LINUX: bench-linux
+  BENCH_WINDOWS: bench-windows
 
 jobs:
   service:
@@ -9,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set version
-      uses: EduardSergeev/project-version-action@v5.1
+      uses: EduardSergeev/project-version-action@v6.5
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
@@ -21,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set version
-      uses: EduardSergeev/project-version-action@v5.1
+      uses: EduardSergeev/project-version-action@v6.5
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
@@ -33,7 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set version
-      uses: EduardSergeev/project-version-action@v5.1
+      uses: EduardSergeev/project-version-action@v6.5
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
@@ -45,7 +50,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set version
-      uses: EduardSergeev/project-version-action@v5.1
+      uses: EduardSergeev/project-version-action@v6.5
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
@@ -67,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set version
-      uses: EduardSergeev/project-version-action@v5.1
+      uses: EduardSergeev/project-version-action@v6.5
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
@@ -75,13 +80,18 @@ jobs:
       run: |
         cd Greeter.Bench
         dotnet run -c Release
+    - name: Upload ${{ env.BENCH_LINUX }} benchmark results
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.BENCH_LINUX }}
+        path: .bench/
 
   bench-windows:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set version
-      uses: EduardSergeev/project-version-action@v5.1
+      uses: EduardSergeev/project-version-action@v6.5
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
@@ -89,3 +99,60 @@ jobs:
       run: |
         cd Greeter.Bench
         dotnet run -c Release
+    - name: Upload ${{ env.BENCH_WINDOWS }} benchmark results
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.BENCH_WINDOWS }}
+        path: .bench/
+  
+  documentation:
+    needs:
+      - bench-linux
+      - bench-windows
+    runs-on: ubuntu-latest
+    env:
+      DOCS_BRANCH: docs
+      DOCS_DIR: ${{ github.workspace }}/docs
+    steps:    
+    - name: Check out ${{ env.DOCS_BRANCH }} branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ env.DOCS_BRANCH }}
+
+    - name: Set version
+      uses: EduardSergeev/project-version-action@v6.5
+      with:
+        time-zone: Australia/Sydney
+        version-file-exists: false
+
+    - name: Clear up ${{ env.DOCS_DIR }} directory
+      run: |
+        rm -fr ${{ env.DOCS_DIR }}
+        mkdir ${{ env.DOCS_DIR }}
+
+    - name: Download ${{ env.BENCH_LINUX }} benchmark results
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ env.BENCH_LINUX }}
+        path: ${{ env.DOCS_DIR }}/${{ env.BENCH_LINUX }}
+
+    - name: Download ${{ env.BENCH_LINUX }} benchmark results
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ env.BENCH_WINDOwS }}
+        path: ${{ env.DOCS_DIR }}/${{ env.BENCH_WINDOwS }}
+
+    - name: Update documentation
+      run: |
+        npm i -g badge-maker
+        badge version "${{ env.VERSION }}" "cadetblue" > "${{ env.DOCS_DIR }}/version.svg"
+        badge bench-linux "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/bench-linux.svg"
+        badge bench-windows "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/bench-windows.svg"
+        git add ${{ env.DOCS_DIR }}/*
+        git -c "user.name=Auto Publisher" -c "user.email=eduard.sergeev@gmail.com" commit --allow-empty -m "Build ${{ env.VERSION }}"
+
+    - name: Push documentation to '${{ env.DOCS_BRANCH }}' branch
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: ad-m/github-push-action@master
+      with:
+        branch: ${{ env.DOCS_BRANCH }}

--- a/Greeter.Bench/Program.cs
+++ b/Greeter.Bench/Program.cs
@@ -1,8 +1,9 @@
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Greeter.Bench;
+using static System.Environment;
 
 BenchmarkRunner.Run<Benchmark>(ManualConfig
-    .Create(DefaultConfig.Instance.WithArtifactsPath(Path.Combine("..", ".bench")))
+    .Create(DefaultConfig.Instance.WithArtifactsPath(Path.Combine("..", ".bench", GetEnvironmentVariable("BENCH_RESULT_SUBPATH") ?? "")))
     .WithOptions(ConfigOptions.DisableOptimizationsValidator)
 );

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # gRPC/Protobuf code generation example
 
-[MSDN gRPC example](https://learn.microsoft.com/en-us/aspnet/core/grpc/) implemented with [IndependentReserve.Grpc.Tools](https://www.nuget.org/packages/IndependentReserve.Grpc.Tools#readme-body-tab)
+[MSDN gRPC example](https://learn.microsoft.com/en-us/aspnet/core/grpc/) implemented with [![IndependentReserve.Grpc.Tools](https://img.shields.io/nuget/dt/IndependentReserve.Grpc.Tools?logo=nuget&label=IndependentReserve.Grpc.Tools&labelColor=%23004880&link=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FIndependentReserve.Grpc.Tools%23readme-body-tab)](https://www.nuget.org/packages/IndependentReserve.Grpc.Tools/#readme-body-tab)
+
 
 [![Build Status](https://github.com/EduardSergeev/GreeterService/workflows/build/badge.svg)](https://github.com/EduardSergeev/GreeterService/actions?query=workflow%3Abuild+branch%3Amaster)
+[![Linux benchmarks](https://eduardsergeev.github.io/GreeterService/bench-linux.svg)](https://eduardsergeev.github.io/GreeterService/bench-linux/results/Greeter.Bench.Benchmark-report.html)
+[![Windows benchmarks](https://eduardsergeev.github.io/GreeterService/bench-windows.svg)](https://eduardsergeev.github.io/GreeterService/bench-windows/results/Greeter.Bench.Benchmark-report.html)
+
 
 
 ## How to run it


### PR DESCRIPTION
- Upload benchmark results to `docs` branch
  From the following jobs:
  - `bench-linux` to `docs/bench-linux/`
  - `bench-windows` to `docs/bench-windows/`
  Also add a few generated badges to `docs`:
  - `version`: `docs/bench-windows.svg`
  - `bench-linux`: `docs/bench-linux.svg`
  - `bench-windows`: `docs/bench-windows.svg`
- Update and `git push` latest `docs` thus publishing `docs` content on [GH Pages](https://eduardsergeev.github.io/GreeterService)
- Add `bench-*` benchmarks results to `docs` branch:
  - [![Linux benchmarks](https://eduardsergeev.github.io/GreeterService/bench-linux.svg)](https://eduardsergeev.github.io/GreeterService/bench-linux/results/Greeter.Bench.Benchmark-report.html)
  - [![Windows benchmarks](https://eduardsergeev.github.io/GreeterService/bench-windows.svg)](https://eduardsergeev.github.io/GreeterService/bench-windows/results/Greeter.Bench.Benchmark-report.html)
- Add some badges
  - ![version](https://eduardsergeev.github.io/GreeterService/version.svg)
  - ![bench-linux](https://eduardsergeev.github.io/GreeterService/bench-linux.svg)
  - ![bench-windows](https://eduardsergeev.github.io/GreeterService/bench-windows.svg)