### PR TITLE
Fix `bench-*` badges colours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,9 +145,9 @@ jobs:
     - name: Update documentation
       run: |
         npm i -g badge-maker
-        badge version "${{ env.VERSION }}" "cadetblue" > "${{ env.DOCS_DIR }}/version.svg"
-        badge bench-linux "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/bench-linux.svg"
-        badge bench-windows "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/bench-windows.svg"
+        badge version "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/version.svg"
+        badge bench-linux "${{ env.VERSION }}" "#E95420" > "${{ env.DOCS_DIR }}/bench-linux.svg"
+        badge bench-windows "${{ env.VERSION }}" "#01BCF3" > "${{ env.DOCS_DIR }}/bench-windows.svg"
         git add ${{ env.DOCS_DIR }}/*
         git -c "user.name=Auto Publisher" -c "user.email=eduard.sergeev@gmail.com" commit --allow-empty -m "Build ${{ env.VERSION }}"
 


### PR DESCRIPTION
- `#E95420`: Linux
- `#01BCF3`: Windows
- Also use standard `green` for `version` badge