### PR TITLE
Switch to `Ir.Grpc.Tools` version `4.0.*`

### DIFF
--- a/Greeter.Grpc/Greeter.Grpc.csproj
+++ b/Greeter.Grpc/Greeter.Grpc.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="3.2.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="4.0.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Greeter.Common\Greeter.Common.csproj" GenerateGrpc="true" />

--- a/Greeter.Test/Greeter.Test.csproj
+++ b/Greeter.Test/Greeter.Test.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="3.2.*" />
+    <PackageReference Include="IndependentReserve.Grpc.Tools" Version="4.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
# What's new in version `4.0.*`
- Handle classes without public fields or properties (e.g. `System.Object`):  
  Such classes (and all properties and fields of such types) are ignored during Protobuf code generation (as well as test code generation). Automapper then sets these properties and fields to class's default values.
- Handle `interface` type members and method arguments:  
  Ignore such members since in C# it is not possible to define `implicit operator` conversion for interface type.
- Handle abstract classes as interfaces (by ignoring them) since it is not possible for AutoMapper to create an instance of abstract class;
- Handle most currently unsupported .NET features by ignoring corresponding entity and issuing compilation warning (with `IRXXXX` code) during the build:
  - Nested classes;
  - Multidimensional arrays;
  - Enums with underlying type smaller than `int` (e.g. `byte`);
  - source interface methods with `ref` and `out` parameters;
  - Source interface generic methods;
  - Source interface properties;
  - Source interface events;
- Better support of nullability annotations:  
  Generate more efficient Protobuf code for .NET class members (and service method parameters) which are not nullable. Protobuf is much more efficient with not-nullable types especially with collections of not-nullable types.
- Collections are now defined as nested Protobuf messages:  
  In the message which uses them instead as a separate standalone message
- Fully support nested .NET collections, e.g. `string[][]`, `List<List<string[]>>`, etc.:  
  Previously such collections would cause compilation error
- Generate tests only for the source interface methods parameters' types:  
  This reduces the number of tests while maintaining the same test code coverage
- Improve code generation performance:  
  Fix the issue with shared types being processed multiple times 