### PR TITLE
Fix links to `doc` branch from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ dotnet run -c Release
 
 ## Benchmark results
 
-Latest benchmark results can be found on [docs](../../docs/docs) branch:
-- [Linux](../../docs/docs/bench-linux/results)
-- [Windows](../../docs/docs/bench-windows/results)
+Latest benchmark results can be found on [docs](../docs/docs) branch:
+- [Linux](../docs/docs/bench-linux/results)
+- [Windows](../docs/docs/bench-windows/results)
 
 <details>
   <summary>Benchmark results example:</summary>


### PR DESCRIPTION
Relative links from `master` should be prefixed by one `../`