### PR TITLE
Fix `Collections` benchmarks `*plot.png` output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,16 +8,6 @@ on:
     branches:
       - master
       
-env:
-  BENCH_LINUX: ubuntu-latest
-  BENCH_WINDOWS: windows-latest
-  BENCH_ARGS: ${{ (github.ref == 'refs/heads/master' || github.event_name == 'pull_request') && '-a ../.bench -f "*"' || '-a ../.bench -j short -f "SingleDto.*"' }}
-  BENCH_ARTIFACTS: |
-    .bench/**/*.csv
-    .bench/**/*.html
-    .bench/**/*.md
-    .bench/**/*plot.png
-
 jobs:
   service:
     runs-on: ubuntu-latest
@@ -92,19 +82,24 @@ jobs:
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
-    - name: Benchmarks warm up
+    - name: Short conversion benchmarks
       run: |
         cd Greeter.Bench
-        dotnet run -c Release -- -a ../.bench -j dry -f "SingleDto.DtoToBinary"
-    - name: Conversion benchmarks '${{ env.VERSION }}'
+        dotnet run -c Release -- -a ../.bench/${{ matrix.os }} -j short -f "SingleDto.*"
+    - name: Full conversion benchmarks '${{ env.VERSION }}'
+      if: ${{ github.ref == 'refs/heads/master' || github.event_name == 'pull_request' }}
       run: |
         cd Greeter.Bench
-        dotnet run -c Release -- ${{ env.BENCH_ARGS }}
-    - name: Upload ${{ matrix.os }} benchmark results
+        dotnet run -c Release -- -a ../.bench/${{ matrix.os }} -f "*"
+    - name: Upload ${{ matrix.os }} benchmarks results
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}
-        path: ${{ env.BENCH_ARTIFACTS }}
+        path: |
+          .bench/**/*.csv
+          .bench/**/*.html
+          .bench/**/*.md
+          .bench/**/*plot.png
  
   documentation:
     needs:
@@ -127,16 +122,10 @@ jobs:
       run: |
         rm -fr ${{ env.DOCS_DIR }}
         mkdir ${{ env.DOCS_DIR }}
-    - name: Download ${{ env.BENCH_LINUX }} benchmark results
+    - name: Download benchmark results
       uses: actions/download-artifact@v3
       with:
-        name: ${{ env.BENCH_LINUX }}
-        path: ${{ env.DOCS_DIR }}/${{ env.BENCH_LINUX }}
-    - name: Download ${{ env.BENCH_WINDOWS }} benchmark results
-      uses: actions/download-artifact@v3
-      with:
-        name: ${{ env.BENCH_WINDOWS }}
-        path: ${{ env.DOCS_DIR }}/${{ env.BENCH_WINDOWS }}
+        path: ${{ env.DOCS_DIR }}
     - name: Update documentation
       run: |
         npm i -g badge-maker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ on:
       - master
       
 env:
-  BENCH_LINUX: bench-linux
-  BENCH_WINDOWS: bench-windows
+  BENCH_LINUX: bench-Linux
+  BENCH_WINDOWS: bench-Windows
   BENCH_ARGS: ${{ (github.ref == 'refs/heads/master' || github.event_name == 'pull_request') && '-a ../.bench -f "*"' || '-a ../.bench -j short -f "SingleDto.*"' }}
   BENCH_ARTIFACTS: |
     .bench/**/*.csv
@@ -77,8 +77,14 @@ jobs:
     - name: docker stop
       run: docker stop greeter-service
 
-  bench-linux:
-    runs-on: ubuntu-latest
+  benchmarks:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Set version
@@ -86,39 +92,23 @@ jobs:
       with:
         time-zone: Australia/Sydney
         version-file: properties/Global.props
+    - name: Benchmarks warm up
+      run: |
+        cd Greeter.Bench
+        dotnet run -c Release -- -a ../.bench -j dry -f "SingleDto.DtoToBinary"
     - name: Conversion benchmarks '${{ env.VERSION }}'
       run: |
         cd Greeter.Bench
         dotnet run -c Release -- ${{ env.BENCH_ARGS }}
-    - name: Upload ${{ env.BENCH_LINUX }} benchmark results
+    - name: Upload bench-${{ runner.os }} benchmark results
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ env.BENCH_LINUX }}
+        name: bench-${{ runner.os }}
         path: ${{ env.BENCH_ARTIFACTS }}
-
-  bench-windows:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set version
-      uses: EduardSergeev/project-version-action@v6.5
-      with:
-        time-zone: Australia/Sydney
-        version-file: properties/Global.props
-    - name: Conversion benchmarks '${{ env.VERSION }}'
-      run: |
-        cd Greeter.Bench
-        dotnet run -c Release -- ${{ env.BENCH_ARGS }}
-    - name: Upload ${{ env.BENCH_WINDOWS }} benchmark results
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ env.BENCH_WINDOWS }}
-        path: ${{ env.BENCH_ARTIFACTS }}
-  
+ 
   documentation:
     needs:
-      - bench-linux
-      - bench-windows
+      - benchmarks
     runs-on: ubuntu-latest
     env:
       DOCS_BRANCH: docs
@@ -142,7 +132,7 @@ jobs:
       with:
         name: ${{ env.BENCH_LINUX }}
         path: ${{ env.DOCS_DIR }}/${{ env.BENCH_LINUX }}
-    - name: Download ${{ env.BENCH_LINUX }} benchmark results
+    - name: Download ${{ env.BENCH_WINDOwS }} benchmark results
       uses: actions/download-artifact@v3
       with:
         name: ${{ env.BENCH_WINDOwS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ on:
       - master
       
 env:
-  BENCH_LINUX: bench-Linux
-  BENCH_WINDOWS: bench-Windows
+  BENCH_LINUX: ubuntu-latest
+  BENCH_WINDOWS: windows-latest
   BENCH_ARGS: ${{ (github.ref == 'refs/heads/master' || github.event_name == 'pull_request') && '-a ../.bench -f "*"' || '-a ../.bench -j short -f "SingleDto.*"' }}
   BENCH_ARTIFACTS: |
     .bench/**/*.csv
@@ -100,10 +100,10 @@ jobs:
       run: |
         cd Greeter.Bench
         dotnet run -c Release -- ${{ env.BENCH_ARGS }}
-    - name: Upload bench-${{ runner.os }} benchmark results
+    - name: Upload ${{ matrix.os }} benchmark results
       uses: actions/upload-artifact@v3
       with:
-        name: bench-${{ runner.os }}
+        name: ${{ matrix.os }}
         path: ${{ env.BENCH_ARTIFACTS }}
  
   documentation:
@@ -132,11 +132,11 @@ jobs:
       with:
         name: ${{ env.BENCH_LINUX }}
         path: ${{ env.DOCS_DIR }}/${{ env.BENCH_LINUX }}
-    - name: Download ${{ env.BENCH_WINDOwS }} benchmark results
+    - name: Download ${{ env.BENCH_WINDOWS }} benchmark results
       uses: actions/download-artifact@v3
       with:
-        name: ${{ env.BENCH_WINDOwS }}
-        path: ${{ env.DOCS_DIR }}/${{ env.BENCH_WINDOwS }}
+        name: ${{ env.BENCH_WINDOWS }}
+        path: ${{ env.DOCS_DIR }}/${{ env.BENCH_WINDOWS }}
     - name: Update documentation
       run: |
         npm i -g badge-maker

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [MSDN gRPC example](https://learn.microsoft.com/en-us/aspnet/core/grpc/) implemented using [IndependentReserve.Grpc.Tools](https://www.nuget.org/packages/IndependentReserve.Grpc.Tools/#readme-body-tab) package
 
 [![Build Status](https://github.com/EduardSergeev/GreeterService/workflows/build/badge.svg)](https://github.com/EduardSergeev/GreeterService/actions?query=workflow%3Abuild+branch%3Amaster)
-[![Linux benchmarks](https://eduardsergeev.github.io/GreeterService/bench-linux.svg)](https://eduardsergeev.github.io/GreeterService/bench-linux/results/SingleDto-report.html)
-[![Windows benchmarks](https://eduardsergeev.github.io/GreeterService/bench-windows.svg)](https://eduardsergeev.github.io/GreeterService/bench-windows/results/SingleDto-report.html)
+[![Linux benchmarks](https://eduardsergeev.github.io/GreeterService/bench-linux.svg)](https://eduardsergeev.github.io/GreeterService/ubuntu-latest/results/SingleDto-report.html)
+[![Windows benchmarks](https://eduardsergeev.github.io/GreeterService/bench-windows.svg)](https://eduardsergeev.github.io/GreeterService/windows-latest/results/SingleDto-report.html)
 
 ## How to run it
 
@@ -46,16 +46,16 @@ dotnet run -c Release
 ## Benchmark results
 
 Latest benchmark results can be found on [docs](../docs/docs) branch:
-- [Linux](../docs/docs/bench-linux/results)
-- [Windows](../docs/docs/bench-windows/results)
+- [Linux](../docs/docs/ubuntu-latest/results)
+- [Windows](../docs/docs/windows-latest/results)
 
 <details>
   <summary>Benchmark results example:</summary>
 
 [Serialisation](Greeter.Bench/StringArraySerialisation.cs) of `string[]` vs `string?[]` collection (vs JSON serialisation as baseline):
 
-<a href="https://eduardsergeev.github.io/GreeterService/bench-linux/results/StringArraySerialisation-report.html">
-    <img src="https://eduardsergeev.github.io/GreeterService/bench-linux/results/StringArraySerialisation-barplot.png" height="500"/>
+<a href="https://eduardsergeev.github.io/GreeterService/ubuntu-latest/results/StringArraySerialisation-report.html">
+    <img src="https://eduardsergeev.github.io/GreeterService/ubuntu-latest/results/StringArraySerialisation-barplot.png" height="500"/>
 </a>
 
 </details>


### PR DESCRIPTION
- Fix missing `Collections-*plot.png` graphs:  
  `*plot.png` output was no generated probably due to R not being ready so we now run short "warm up" step to set up R properly
- Use GH runner name for artifacts names and result directory names:
  - Linux: `ubuntu-latest`
  - Windows: `windows-latest`